### PR TITLE
Database settings bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - Unreleased
+
+### auth0-bitbucket-deploy v2.6.4
+### auth0-github-deploy v2.6.2
+### auth0-gitlab-deploy v2.7.2
+### auth0-visualstudio-deploy v2.5.3
+
+- #### Fixed
+  - Database settings without scripts bug fixed.
+
 ## [1.1.2] - 2019-02-07
 
 ### auth0-bitbucket-deploy v2.6.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Auth0 Deployment Extensions",
   "engines": {
     "node": "5.9.0"

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -267,7 +267,7 @@ const unifyItem = (item, type) => {
 
       _.forEach(item.scripts, (script) => { customScripts[script.name] = script.scriptFile; });
 
-      if (item.scripts || item.scripts.length) {
+      if (item.scripts && item.scripts.length) {
         options.customScripts = customScripts;
         options.enabledDatabaseCustomization = true;
       }

--- a/webtask-templates/bitbucket.json
+++ b/webtask-templates/bitbucket.json
@@ -1,7 +1,7 @@
 {
   "title": "Bitbucket Deployments",
   "name": "auth0-bitbucket-deploy",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "preVersion": "2.5.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from Bitbucket.",

--- a/webtask-templates/github.json
+++ b/webtask-templates/github.json
@@ -1,7 +1,7 @@
 {
   "title": "GitHub Deployments",
   "name": "auth0-github-deploy",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "preVersion": "2.5.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Pages, Rules and Custom Database Connections from GitHub.",

--- a/webtask-templates/gitlab.json
+++ b/webtask-templates/gitlab.json
@@ -1,7 +1,7 @@
 {
   "title": "GitLab Deployments",
   "name": "auth0-gitlab-deploy",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "preVersion": "2.6.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from GitLab.",

--- a/webtask-templates/visualstudio.json
+++ b/webtask-templates/visualstudio.json
@@ -1,7 +1,7 @@
 {
   "title": "Visual Studio Team Services Deployments",
   "name": "auth0-visualstudio-deploy",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "preVersion": "2.4.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from Visual Studio Team Services.",


### PR DESCRIPTION
## ✏️ Changes
  `enabledDatabaseCustomization` is required to be `true` for custom scripts. Due to bug the extension was setting `enabledDatabaseCustomization` to `true` even if there were no scripts. Fixing that in this change.
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1550836306017600
Support ticket: https://auth0.lightning.force.com/lightning/r/Case/5001G00000cdXplQAE/view
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  