### PR TITLE
Bitbucket pagination rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2019-03-25
+
+### auth0-bitbucket-deploy v2.7.2
+
+- #### Fixed
+  - Bitbucket API pagination issue fixed.
+
 ## [1.2.2] - 2019-03-19
 
 ### auth0-visualstudio-deploy v2.6.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Auth0 Deployment Extensions",
   "engines": {
     "node": "5.9.0"

--- a/server/lib/providers/bitbucketApi.js
+++ b/server/lib/providers/bitbucketApi.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import async from 'async';
 import request from 'request';
 
 export default class Bitbucket {
@@ -74,51 +73,33 @@ Bitbucket.prototype.buildEndpoint = function buildEndpoint(path, params) {
 };
 
 Bitbucket.prototype.getAll = function getAll(options, callback) {
-  const concurrency = 2;
   const perPage = 100;
   const result = [];
 
   options.url = options.url + '?pagelen=' + perPage;
 
-  const getTotals = (cb) =>
-    this.request(options, (error, data) => {
-      if (error) {
-        cb(error);
-      } else {
-        data.values.forEach(item => result.push(item));
-        cb(null, data.size);
-      }
-    });
+  const getPage = (url, cb) => {
+    const pageOptions = { ...options };
+    if (url) {
+      pageOptions.url = url;
+    }
 
-  const getPage = (page, cb) => {
-    const pageOptions = { ...options, url: options.url + '&page=' + (page + 1) };
     this.request(pageOptions, (error, data) => {
       if (error) {
-        cb(error);
-      } else {
-        data.values.forEach(item => result.push(item));
-        cb(null);
+        return cb(error);
       }
+
+      data.values.forEach(item => result.push(item));
+
+      if (data.next) {
+        return getPage(data.next, cb);
+      }
+
+      return cb(null, result);
     });
   };
 
-  return getTotals((err, total) => {
-    if (err) {
-      return callback(err);
-    }
-
-    if (total === 0 || result.length >= total) {
-      return callback(null, result);
-    }
-
-    return async.timesLimit(total, concurrency, getPage, (error) => {
-      if (error) {
-        return callback(error);
-      }
-
-      return callback(null, result);
-    });
-  });
+  return getPage(null, callback);
 };
 
 Bitbucket.prototype.doRequest = function doRequest(isTree, path, params, callback) {

--- a/webtask-templates/bitbucket.json
+++ b/webtask-templates/bitbucket.json
@@ -1,7 +1,7 @@
 {
   "title": "Bitbucket Deployments",
   "name": "auth0-bitbucket-deploy",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "preVersion": "2.6.4",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from Bitbucket.",


### PR DESCRIPTION
## ✏️ Changes
  According to [these docs](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/src/%7Bnode%7D/%7Bpath%7D) we cannot rely on `data.size`, as `"Total number of objects in the response. This is an optional element that is not provided in all responses, as it can be expensive to compute."`
Using `next` (Link to the next page if it exists. The last page of a collection does not have this value.) instead.
  
## 🔗 References
  Bitbucket API docs: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/src/%7Bnode%7D/%7Bpath%7D
 Slack: https://auth0.slack.com/archives/C9170558S/p1553497838285100
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  