### PR TITLE
Allow disabling error_page

### DIFF
--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -244,8 +244,13 @@ const unifyItem = (item, type) => {
     case 'pages': {
       const meta = extractFileContent(item.metadataFile);
       const { enabled } = meta;
+      const page = { html: item.htmlFile, name: item.name, enabled };
+      if (page.name === 'error_page') {
+        page.html = (typeof enabled === 'undefined' || enabled) ? page.html : '';
+        delete page.enabled;
+      }
 
-      return ({ html: item.htmlFile, name: item.name, enabled });
+      return page;
     }
 
     case 'emailTemplates': {

--- a/tests/server/utils.tests.js
+++ b/tests/server/utils.tests.js
@@ -110,4 +110,48 @@ describe('unifyData', () => {
         done();
       });
   });
+
+  it('should remove enabled prop form error_page', (done) => {
+    const data = {
+      pages: [
+        {
+          name: 'error_page',
+          htmlFile: 'Page Content',
+          metadata: true,
+          metadataFile: '{ "enabled":true }'
+        }
+      ]
+    };
+
+    utils.unifyData(data)
+      .then((unified) => {
+        expect(unified.pages[0].name).toEqual('error_page');
+        expect(unified.pages[0].html).toEqual('Page Content');
+        expect(unified.pages[0].enabled).toEqual(undefined);
+
+        done();
+      });
+  });
+
+  it('should clear html prop of error_page if disabled', (done) => {
+    const data = {
+      pages: [
+        {
+          name: 'error_page',
+          htmlFile: 'Page Content',
+          metadata: true,
+          metadataFile: '{ "enabled":false }'
+        }
+      ]
+    };
+
+    utils.unifyData(data)
+      .then((unified) => {
+        expect(unified.pages[0].name).toEqual('error_page');
+        expect(unified.pages[0].html).toEqual('');
+        expect(unified.pages[0].enabled).toEqual(undefined);
+
+        done();
+      });
+  });
 });


### PR DESCRIPTION
## ✏️ Changes
  `error_page` cannot be disabled (`enabled: false`), but we can remove `html` based on that flag. Removing `html` of `error_page` will lead to using default error page.
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/projects/ESD/queues/issue/ESD-235
  
## 🎯 Testing
✅ This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time