### PR TITLE
Db conn customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.3.1] - 2019-04-22
+
+### auth0-bitbucket-deploy v2.8.1
+### auth0-github-deploy v2.8.1
+### auth0-gitlab-deploy v2.9.1
+### auth0-visualstudio-deploy v2.7.1
+
+- #### Fixed
+  - Database connection custom scripts won't be sent, if database customization is disabled in `settings.json`
+  
 ## [1.3.0] - 2019-04-12
 
 ### auth0-bitbucket-deploy v2.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "1.2.4",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Auth0 Deployment Extensions",
   "engines": {
     "node": "5.9.0"

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -268,7 +268,7 @@ const unifyItem = (item, type) => {
 
       _.forEach(item.scripts, (script) => { customScripts[script.name] = script.scriptFile; });
 
-      if (item.scripts && item.scripts.length) {
+      if (item.scripts && item.scripts.length && options.enabledDatabaseCustomization !== false) {
         options.customScripts = customScripts;
         options.enabledDatabaseCustomization = true;
       }

--- a/tests/server/mocks/repo-data-mock.js
+++ b/tests/server/mocks/repo-data-mock.js
@@ -91,5 +91,23 @@ module.exports = {
     connections: [],
     rulesConfigs: [],
     resourceServers: []
+  },
+  dbScriptsNoCustom: {
+    rules: [],
+    databases: [ {
+      name: 'Database',
+      settings: '{ "options": { "enabledDatabaseCustomization": false } }',
+      scripts: [ {
+        name: 'login',
+        scriptFile: 'Database login script'
+      } ]
+    } ],
+    emailTemplates: [],
+    pages: [],
+    clients: [],
+    clientGrants: [],
+    connections: [],
+    rulesConfigs: [],
+    resourceServers: []
   }
 };

--- a/tests/server/utils.tests.js
+++ b/tests/server/utils.tests.js
@@ -110,4 +110,25 @@ describe('unifyData', () => {
         done();
       });
   });
+
+  it('should unify database and not include customScripts if customization is disabled', (done) => {
+    utils.unifyData(assets.dbScriptsNoCustom)
+      .then((unified) => {
+        expect(unified.databases[0].name).toEqual('Database');
+        expect(unified.databases[0].options.customScripts).toNotExist();
+        expect(unified.databases[0].options.enabledDatabaseCustomization).toEqual(false);
+
+        expect(unified.rules).toNotExist();
+        expect(unified.rulesConfigs).toNotExist();
+        expect(unified.emailProvider).toNotExist();
+        expect(unified.emailTemplates).toNotExist();
+        expect(unified.pages).toNotExist();
+        expect(unified.clients).toNotExist();
+        expect(unified.clientGrants).toNotExist();
+        expect(unified.connections).toNotExist();
+        expect(unified.resourceServers).toNotExist();
+
+        done();
+      });
+  });
 });

--- a/webtask-templates/bitbucket.json
+++ b/webtask-templates/bitbucket.json
@@ -1,7 +1,7 @@
 {
   "title": "Bitbucket Deployments",
   "name": "auth0-bitbucket-deploy",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "preVersion": "2.7.2",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from Bitbucket.",

--- a/webtask-templates/github.json
+++ b/webtask-templates/github.json
@@ -1,7 +1,7 @@
 {
   "title": "GitHub Deployments",
   "name": "auth0-github-deploy",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "preVersion": "2.7.1",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Pages, Rules and Custom Database Connections from GitHub.",

--- a/webtask-templates/gitlab.json
+++ b/webtask-templates/gitlab.json
@@ -1,7 +1,7 @@
 {
   "title": "GitLab Deployments",
   "name": "auth0-gitlab-deploy",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "preVersion": "2.8.1",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from GitLab.",

--- a/webtask-templates/visualstudio.json
+++ b/webtask-templates/visualstudio.json
@@ -1,7 +1,7 @@
 {
   "title": "Visual Studio Team Services Deployments",
   "name": "auth0-visualstudio-deploy",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "preVersion": "2.6.2",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from Visual Studio Team Services.",


### PR DESCRIPTION
## ✏️ Changes
 These changes meant to allow user to keep db-scripts in the repo even if db customization is disabled. In this case (`enabledDatabaseCustomization: false` in `settings.json`), the extension won't send db scripts to API2.
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/projects/ESD/queues/custom/321/ESD-284
  
## 🎯 Testing
✅ This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  