### PR TITLE
[project-name]/[repo-name] format for vsts git-repo

### DIFF
--- a/server/lib/providers/tfs-git.js
+++ b/server/lib/providers/tfs-git.js
@@ -323,19 +323,20 @@ export const getChanges = ({ repositoryId, branch }) =>
 /*
  * Get a repository id by name.
  */
-const getRepositoryId = () =>
-  getApi()
-    .then(api => api.getRepositories())
+const getRepositoryId = () => {
+  const parts = config('REPOSITORY').split('/');
+  const [ projectName, repoName ] = (parts.length === 2) ? parts : [ null, config('REPOSITORY') ];
+
+  return getApi()
+    .then(api => api.getRepositories(projectName))
     .then(repositories => {
       if (!repositories) return null;
 
-      let rID = null;
-      const repository = repositories.filter(f => f.name === config('REPOSITORY'));
+      const repository = repositories.find(f => f.name === repoName);
 
-      if (repository[0] && repository[0].id) rID = repository[0].id;
-
-      return rID;
+      return repository && repository.id;
     });
+};
 
 /*
  * Get default options for manual deploy


### PR DESCRIPTION
## ✏️ Changes
  In VSTS (Azure DevOps) git repo name isn't unique. Instance can have several projects, and each project can have a repo with the same name. This change will allow customer to specify project name in format `project/repo` in `REPOSITORY` secret.
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/browse/ESD-396
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time