### PR TITLE
Branch name issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.4.2] - 2019-06-05
+
+### auth0-gitlab-deploy v2.10.2
+### auth0-visualstudio-deploy v2.8.2
+
+- #### Fixed
+  - Issue with branches, names of which are containing `/` character.
+  
 ## [1.4.1] - 2019-06-05
 
 ### auth0-bitbucket-deploy v2.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.4.2] - Unreleased
+## [1.4.2] - 2019-06-14
 
 ### auth0-gitlab-deploy v2.10.2
 ### auth0-visualstudio-deploy v2.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.4.2] - 2019-06-05
+## [1.4.2] - Unreleased
 
 ### auth0-gitlab-deploy v2.10.2
 ### auth0-visualstudio-deploy v2.8.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Auth0 Deployment Extensions",
   "engines": {
     "node": "5.9.0"

--- a/server/lib/middlewares/gitlab.js
+++ b/server/lib/middlewares/gitlab.js
@@ -5,13 +5,14 @@ import config from '../config';
 
 
 const parse = (headers, { ref = '', commits = [], project = {}, project_id = '', user_email = '', event_name = '', checkout_sha = '' }) => { // eslint-disable-line camelcase
-  const refParts = ref.split('/');
+  // If the ref starts with "refs/heads/", strip it
+  const branch = ref.replace(/^refs\/heads\//i, '');
 
   return {
     id: checkout_sha,
     projectId: project_id,
     event: event_name,
-    branch: refParts.length === 3 ? refParts[2] : '',
+    branch: branch,
     commits,
     repository: project.path_with_namespace,
     user: user_email,

--- a/webtask-templates/gitlab.json
+++ b/webtask-templates/gitlab.json
@@ -1,7 +1,7 @@
 {
   "title": "GitLab Deployments",
   "name": "auth0-gitlab-deploy",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "preVersion": "2.9.1",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from GitLab.",

--- a/webtask-templates/visualstudio.json
+++ b/webtask-templates/visualstudio.json
@@ -1,7 +1,7 @@
 {
   "title": "Visual Studio Team Services Deployments",
   "name": "auth0-visualstudio-deploy",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "preVersion": "2.7.1",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from Visual Studio Team Services.",


### PR DESCRIPTION
## ✏️ Changes
  `gitlab` and `tfs-git` cannot handle branches with `/` char in the name. This change should fix this.
Fixes #32 
  
## 🔗 References
  GH issue: #32 

## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  