### PR TITLE
Add artifact generation to CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm run build
       - run:
           name: Compress Artifacts
-          command: tar -cvf dist.tar dist/
+          command: tar -zcvf dist.tar.gz dist/
       - store_artifacts:
           path: dist.tar
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,14 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run test
+
+      - run: npm run build
+      - run:
+          name: Compress Artifacts
+          command: tar -cvf dist.tar dist/
+      - store_artifacts:
+          path: dist.tar
+
       - persist_to_workspace:
           root: ~/repo
           paths: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,45 +2,66 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
 jobs:
-  build:
-    docker:
-      - image: circleci/node:8.12
-
+  build_and_test:
     working_directory: ~/repo
+    parameters:
+      v:
+        type: string
+        default: "8"
+    docker:
+      - image: circleci/node:<< parameters.v >>
 
     steps:
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - npm-dependencies-{{ checksum "package-lock.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - npm-dependencies-
-
-      #- run:
-      #    name: Install FOSSA
-      #    command: |
-      #      curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
-
-      - run: npm install
-
-      #- run:
-      #    name: FOSSA Init
-      #    command: fossa init
-      #- run:
-      #    name: FOSSA Analyze
-      #    command: fossa analyze
-      #- run:
-      #    name: FOSSA Test
-      #    command: fossa test
-
-      - save_cache:
-          name: Save npm packages to cache
-          key: npm-dependencies-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-
+      - run: npm ci
       - run: npm run test
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
+
+  deploy:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/node:12
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run: npm run build
+      - run:
+          name: Compress Artifacts
+          command: tar -cvf dist.tar dist/
+      - store_artifacts:
+          path: dist.tar
+
+workflows:
+  version: 2.1
+  build_and_test:
+    jobs:
+      - build_and_test:
+          name: build_and_test_node8
+          v: "8"
+      - build_and_test:
+          name: build_and_test_node12
+          v: "12"
+      - build_and_test:
+          name: build_and_test_node13
+          v: "13"
+  build_test_and_deploy:
+    jobs:
+      - build_and_test:
+          v: "8" # Change this when we move to node 12.
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: master
+      - deploy:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,6 @@ jobs:
       - checkout
       - run: npm ci
       - run: npm run test
-
-      - run: npm run build
-      - run:
-          name: Compress Artifacts
-          command: tar -cvf dist.tar dist/
-      - store_artifacts:
-          path: dist.tar
-
       - persist_to_workspace:
           root: ~/repo
           paths: .

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 These extensions makes it possible to deploy Rules and Database Connection scripts from Bitbucket, Github, Gitlab or VisualStudio to Auth0.
 
 ## Usage
+
 There is more extensive documentation online for how the files are expected to be laid out to work with the source control configuration utilities [here](https://auth0.com/docs/extensions/bitbucket-deploy).
 
 #### Organize your repository
@@ -43,7 +44,9 @@ repository =>
 ```
 
 ##### Roles
+
 In the .json file you can specify roles options, the name of the file does not matter. Example:
+
 ```
 {
   "name": "Role name",
@@ -58,13 +61,15 @@ In the .json file you can specify roles options, the name of the file does not m
 ```
 
 ##### Clients
+
 The name of the file is the name of the client that is created or updated.
 
-In the .json file you can put the same json you would put when using the Management API for creating clients.  It will only try to keep the fields specified inline with what is configured already.  If a client doesn't exist yet, it will create it.
-
+In the .json file you can put the same json you would put when using the Management API for creating clients. It will only try to keep the fields specified inline with what is configured already. If a client doesn't exist yet, it will create it.
 
 ##### Clients Grants
+
 In the .json file you can specify client grants options, the name of the file does not matter. Example:
+
 ```
 {
   "client_id": "client1",
@@ -76,15 +81,19 @@ In the .json file you can specify client grants options, the name of the file do
 ```
 
 ##### Resource servers
+
 The name of the file is the name of the resource server that is created or updated.
 
-In the .json file you can put the same json you would put when using the Management API for creating resource servers.  It will only try to keep the fields specified inline with what is configured already.  If a resource server doesn't exist yet, it will create it.
+In the .json file you can put the same json you would put when using the Management API for creating resource servers. It will only try to keep the fields specified inline with what is configured already. If a resource server doesn't exist yet, it will create it.
 
 ##### Database Connections
+
 See Database Connection configuration [here](https://auth0.com/docs/extensions/bitbucket-deploy#deploy-database-connection-scripts)
 
 ##### Rules Configs
+
 In the .json file you can define value for rule-config, while filename is a key:
+
 ```
 {
   "value": "some-secret-value"
@@ -92,11 +101,13 @@ In the .json file you can define value for rule-config, while filename is a key:
 ```
 
 ##### Rules
+
 See Rules configuration [here](https://auth0.com/docs/extensions/bitbucket-deploy#deploy-rules)
 
 NOTE: There is not currently a way to mark rules as manual yet, that will become part of the configuration file in the future.
 
 ##### Custom Pages
+
 See Custom Pages configuration [here](https://auth0.com/docs/extensions/bitbucket-deploy#deploy-hosted-pages)
 
 ## Running
@@ -140,11 +151,14 @@ https://YOU.ngrok.io/login
 
 ### Deployment
 
+Deployment artifacts are automatically generated when a git tag (or a github release) is created with the `v*` format. These artifacts are stored on the circle build job. These can then be downloaded and uploaded via the Extensions Deployer Tool.
+
 Since this is a monorepo, there are now 2 parts, the UI and the webtasks. The UI is shared by each individual webtask and is deployed seperately and manually.
 
 ```
 npm run build
 ```
+
 The output will be in the `/dist` directory. The root will contain the UI files and each extension will have its own directory. If updating an extension without a change on the client, use the deploy tool to deploy only the bundle (no need to upload the client files).
 
 If the client has been updated, the version number needs to be updated here: https://github.com/auth0-extensions/auth0-deploy-extensions/blob/master/package.json#L78


### PR DESCRIPTION
## ✏️ Changes
  
Updating the CircleCI config to build and store the extension assets when a git tag is created.

This allows us to get the assets from CI without building it locally when a deployment is needed.

This is an example of the artifact output: https://app.circleci.com/pipelines/github/auth0-extensions/auth0-deploy-extensions/63/workflows/43b292b6-34e8-4aa0-b310-a98bb0893edd/jobs/62/artifacts