### PR TITLE
github: update PR template to include canirequire dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,16 @@ If there were visual changes to the application with this change, please include
 ## 🔗 References
   
 > Include at at least one link to an explanation + requirements for this change, and more if at all possible. Typically this is a Jira/GitHub Issue, but could also be links to Zendesk tickets, RFCs, rollout plan or Slack conversations (for Slack conversations, make sure you provide a summary of the conversation under “Changes”).
-  
+
+## 🛑 Runtime Dependencies
+
+> If you have updated the version of any package listed under `auth0-extension.externals` in `package.json`, please ensure the updated version has already been made available in [canirequire](https://auth0-extensions.github.io/canirequire/).
+
+✅🚫 This change does not require any new version of packages
+
+✅🚫 All packages and versions required by this change have been included in [canirequire](https://auth0-extensions.github.io/canirequire/)
+
+
 ## 🎯 Testing
   
 > Describe how this can be tested by reviewers. Please be specific about anything not tested and reasons why.


### PR DESCRIPTION
## ✏️ Changes
  
Updated GitHub PR template with a check on canirequire dependencies
  
## 📷 Screenshots
 
N/A
  
## 🔗 References
  
N/A

## 🛑 Runtime Dependencies

🚫 This change does not require any new version of packages

✅ All packages and versions required by this change have been included in [canirequire](https://auth0-extensions.github.io/canirequire/)


## 🎯 Testing
   
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
  
N/A
  
## 🔥 Rollback
  
Revert the commit
  
### 📄 Procedure

N/A

## 🖥 Appliance

N/A