### PR TITLE
[ESD-10039] fix: custom db script should be included even when customization is disabled

### DIFF
--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -362,10 +362,13 @@ const unifyItem = (item, type, mappings) => {
 
       _.forEach(item.scripts, (script) => { customScripts[script.name] = extractFileContent(script.scriptFile, mappings, true); });
 
-      if (item.scripts && item.scripts.length && options.enabledDatabaseCustomization !== false) {
+      if (item.scripts && item.scripts.length) {
+        if (options.enabledDatabaseCustomization !== false) {
+          options.enabledDatabaseCustomization = true;
+        }
         options.customScripts = customScripts;
-        options.enabledDatabaseCustomization = true;
       }
+
 
       return ({ ...settings, options, strategy: 'auth0', name: item.name });
     }

--- a/tests/server/utils.tests.js
+++ b/tests/server/utils.tests.js
@@ -140,11 +140,12 @@ describe('unifyData', () => {
       });
   });
 
-  it('should unify database and not include customScripts if customization is disabled', (done) => {
+  it('should unify database and always include customScripts even if customization is disabled', (done) => {
     utils.unifyData(assets.dbScriptsNoCustom)
       .then((unified) => {
         expect(unified.databases[0].name).toEqual('Database');
-        expect(unified.databases[0].options.customScripts).toNotExist();
+        expect(unified.databases[0].options.customScripts).toBeAn('object');
+        expect(unified.databases[0].options.customScripts.login).toEqual('Database login script');
         expect(unified.databases[0].options.enabledDatabaseCustomization).toEqual(false);
 
         expect(unified.rules).toNotExist();


### PR DESCRIPTION
## ✏️ Changes
  
The DB custom scripts are now included in deployment even when customization is disabled, which is aligned with the management dashboard behavior.
  
## 📷 Screenshots
n/a
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/ESD-10039

## 🛑 Runtime Dependencies

🚫 This change does not require any new version of packages


## 🎯 Testing
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will use the deploy extension to deploy a DB connection with customization disabled. The scripts should still be deployed.
  
## 🔥 Rollback

We will rollback if the deploy extensions cease to function
  
### 📄 Procedure

Revert the extensions.json in CDN or revert the PR and release a new minor version.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
