### PR TITLE
Fix external dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
       "@octokit/rest@17.1.4",
       "auth0@2.27.0",
       "async@2.1.2",
-      "auth0-source-control-extension-tools@4.1.7",
+      "auth0-source-control-extension-tools@4.1.9",
       "axios@0.18.0",
       "bluebird@3.4.6",
       "compression@1.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-deploy-extensions",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Auth0 Deployment Extensions",
   "engines": {
     "node": "5.9.0"

--- a/webtask-templates/bitbucket.json
+++ b/webtask-templates/bitbucket.json
@@ -1,7 +1,7 @@
 {
   "title": "Bitbucket Deployments",
   "name": "auth0-bitbucket-deploy",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "preVersion": "2.10.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from Bitbucket.",

--- a/webtask-templates/github.json
+++ b/webtask-templates/github.json
@@ -1,7 +1,7 @@
 {
   "title": "GitHub Deployments",
   "name": "auth0-github-deploy",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "preVersion": "2.10.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Pages, Rules and Custom Database Connections from GitHub.",

--- a/webtask-templates/gitlab.json
+++ b/webtask-templates/gitlab.json
@@ -1,7 +1,7 @@
 {
   "title": "GitLab Deployments",
   "name": "auth0-gitlab-deploy",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "preVersion": "2.11.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from GitLab.",

--- a/webtask-templates/visualstudio.json
+++ b/webtask-templates/visualstudio.json
@@ -1,7 +1,7 @@
 {
   "title": "Visual Studio Team Services Deployments",
   "name": "auth0-visualstudio-deploy",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "preVersion": "2.9.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Hosted Pages, Rules and Custom Database Connections from Visual Studio Team Services.",


### PR DESCRIPTION
## ✏️ Changes
  
Previous dependency bump in #92 didn't update the externals.

## 📷 Screenshots
 
n/a
  
## 🔗 References
- #92 

## 🛑 Runtime Dependencies


🚫 This change does not require any new version of packages

✅ The minor or major version of this package has been bumped because this change requires a new version of packages

✅ All packages and versions required by this change have been included in [canirequire](https://auth0-extensions.github.io/canirequire/)


## 🎯 Testing
   
✅ This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
    
In order to verify that the deployment was successful, one of the deploy extension (github/gitlab/bitbucket/vsteam) needs be installed new or auto-upgraded (since this is a micro version update). Then a successful repo deployment be tested.

  
## 🔥 Rollback
  
We will rollback if the upgraded deploy extension does not work.
  
### 📄 Procedure
  
Revert the change in this PR (downgrade the version of source-control-extension-tools), create a new micro version, then deploy. 
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.