### PR TITLE
[DXEC-1225] chore: setting deprecated flags

### DIFF
--- a/webtask-templates/bitbucket.json
+++ b/webtask-templates/bitbucket.json
@@ -1,5 +1,6 @@
 {
   "title": "Bitbucket Deployments",
+  "deprecated": true,
   "name": "auth0-bitbucket-deploy",
   "version": "3.7.2",
   "preVersion": "2.10.0",

--- a/webtask-templates/github.json
+++ b/webtask-templates/github.json
@@ -1,5 +1,6 @@
 {
   "title": "GitHub Deployments",
+  "deprecated": true,
   "name": "auth0-github-deploy",
   "version": "3.7.2",
   "preVersion": "2.10.0",

--- a/webtask-templates/gitlab.json
+++ b/webtask-templates/gitlab.json
@@ -1,5 +1,6 @@
 {
   "title": "GitLab Deployments",
+  "deprecated": true,
   "name": "auth0-gitlab-deploy",
   "version": "3.7.2",
   "preVersion": "2.11.0",

--- a/webtask-templates/visualstudio.json
+++ b/webtask-templates/visualstudio.json
@@ -1,5 +1,6 @@
 {
   "title": "Visual Studio Team Services Deployments",
+  "deprecated": true,
   "name": "auth0-visualstudio-deploy",
   "version": "3.7.2",
   "preVersion": "2.9.0",


### PR DESCRIPTION
## ✏️ Changes
  
Setting `deprecated` flags for the extensions

## 📷 Screenshots
 
n/a
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/DXEX-1225

## 🛑 Runtime Dependencies

✅ This change does not require any new version of packages

## 🎯 Testing

n/a
  
## 🚀 Deployment
    
⚠️ This should not be merged until:
- Other condition: The public deprecation notice is published
  
## 🎡 Rollout

The artifacts requires manual roll out 
  
## 🔥 Rollback
  
n/a
  
### 📄 Procedure
  
Revert the commit and make a new release of the extensions
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
